### PR TITLE
fix(@aws-amplify/interactions): fix interactions bugs with aws-sdk-js-v3

### DIFF
--- a/packages/aws-amplify-angular/src/components/interactions/chatbot/aws-lex-audio.js
+++ b/packages/aws-amplify-angular/src/components/interactions/chatbot/aws-lex-audio.js
@@ -106,28 +106,11 @@
 							if (!audioSupported) {
 								throw new Error(UNSUPPORTED);
 							}
-							resumeAudioContext()
-								.then(() => {
-									recorder = audioRecorder.createRecorder(
-										silenceDetectionConfig
-									);
-									recorder.record(onSilence, visualizer);
-								})
-								.catch(err => {
-									throw new Error(err);
-								});
-						};
-
-						/**
-						 * Resumes audioContext if it is suspended. No-op if it not.
-						 */
-						const resumeAudioContext = () => {
-							const audioContext = audioRecorder.audioContext();
-							if (audioContext.state !== 'suspended') {
-								return Promise.resolve();
-							} else {
-								return audioContext.resume();
-							}
+							const context = audioRecorder.audioContext();
+							context.resume().then(() => {
+								recorder = audioRecorder.createRecorder(silenceDetectionConfig);
+								recorder.record(onSilence, visualizer);
+							});
 						};
 
 						/**

--- a/packages/aws-amplify-angular/src/components/interactions/chatbot/aws-lex-audio.js
+++ b/packages/aws-amplify-angular/src/components/interactions/chatbot/aws-lex-audio.js
@@ -106,8 +106,28 @@
 							if (!audioSupported) {
 								throw new Error(UNSUPPORTED);
 							}
-							recorder = audioRecorder.createRecorder(silenceDetectionConfig);
-							recorder.record(onSilence, visualizer);
+							resumeAudioContext()
+								.then(() => {
+									recorder = audioRecorder.createRecorder(
+										silenceDetectionConfig
+									);
+									recorder.record(onSilence, visualizer);
+								})
+								.catch(err => {
+									throw new Error(err);
+								});
+						};
+
+						/**
+						 * Resumes audioContext if it is suspended. No-op if it not.
+						 */
+						const resumeAudioContext = () => {
+							const audioContext = audioRecorder.audioContext();
+							if (audioContext.state !== 'suspended') {
+								return Promise.resolve();
+							} else {
+								return audioContext.resume();
+							}
 						};
 
 						/**

--- a/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
@@ -436,7 +436,8 @@ function ChatBotInputs(props) {
 	const handleMicButton = props.handleMicButton;
 	const micText = props.micText;
 	const submit = props.submit;
-
+	let placeholder;
+	
 	if (voiceEnabled && textEnabled) {
 		// @ts-ignore
 		placeholder = 'Type your message or tap 🎤';

--- a/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
@@ -437,7 +437,7 @@ function ChatBotInputs(props) {
 	const micText = props.micText;
 	const submit = props.submit;
 	let placeholder;
-	
+
 	if (voiceEnabled && textEnabled) {
 		// @ts-ignore
 		placeholder = 'Type your message or tap 🎤';

--- a/packages/aws-amplify-react/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react/src/Interactions/ChatBot.tsx
@@ -204,8 +204,7 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 			options: {
 				messageType: 'voice',
 			},
-		};
-
+		} as const;
 		const response = await Interactions.send(
 			this.props.botName,
 			interactionsMessage

--- a/packages/aws-amplify-react/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react/src/Interactions/ChatBot.tsx
@@ -204,7 +204,7 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 			options: {
 				messageType: 'voice',
 			},
-		} as const;
+		};
 		const response = await Interactions.send(
 			this.props.botName,
 			interactionsMessage

--- a/packages/aws-amplify-react/src/Interactions/aws-lex-audio.tsx
+++ b/packages/aws-amplify-react/src/Interactions/aws-lex-audio.tsx
@@ -112,8 +112,28 @@
 							if (!audioSupported) {
 								throw new Error(UNSUPPORTED);
 							}
-							recorder = audioRecorder.createRecorder(silenceDetectionConfig);
-							recorder.record(onSilence, visualizer);
+							resumeAudioContext()
+								.then(() => {
+									recorder = audioRecorder.createRecorder(
+										silenceDetectionConfig
+									);
+									recorder.record(onSilence, visualizer);
+								})
+								.catch(err => {
+									throw new Error(err);
+								});
+						};
+
+						/**
+						 * Resumes audioContext if it is suspended. No-op if it not.
+						 */
+						const resumeAudioContext = (): Promise<void> => {
+							const audioContext = audioRecorder.audioContext();
+							if (audioContext.state !== 'suspended') {
+								return Promise.resolve();
+							} else {
+								return audioContext.resume();
+							}
 						};
 
 						/**

--- a/packages/aws-amplify-react/src/Interactions/aws-lex-audio.tsx
+++ b/packages/aws-amplify-react/src/Interactions/aws-lex-audio.tsx
@@ -112,28 +112,11 @@
 							if (!audioSupported) {
 								throw new Error(UNSUPPORTED);
 							}
-							resumeAudioContext()
-								.then(() => {
-									recorder = audioRecorder.createRecorder(
-										silenceDetectionConfig
-									);
-									recorder.record(onSilence, visualizer);
-								})
-								.catch(err => {
-									throw new Error(err);
-								});
-						};
-
-						/**
-						 * Resumes audioContext if it is suspended. No-op if it not.
-						 */
-						const resumeAudioContext = (): Promise<void> => {
-							const audioContext = audioRecorder.audioContext();
-							if (audioContext.state !== 'suspended') {
-								return Promise.resolve();
-							} else {
-								return audioContext.resume();
-							}
+							const context = audioRecorder.audioContext();
+							context.resume().then(() => {
+								recorder = audioRecorder.createRecorder(silenceDetectionConfig);
+								recorder.record(onSilence, visualizer);
+							});
 						};
 
 						/**

--- a/packages/aws-amplify-vue/src/components/interactions/aws-lex-audio.js
+++ b/packages/aws-amplify-vue/src/components/interactions/aws-lex-audio.js
@@ -106,28 +106,11 @@
 							if (!audioSupported) {
 								throw new Error(UNSUPPORTED);
 							}
-							resumeAudioContext()
-								.then(() => {
-									recorder = audioRecorder.createRecorder(
-										silenceDetectionConfig
-									);
-									recorder.record(onSilence, visualizer);
-								})
-								.catch(err => {
-									throw new Error(err);
-								});
-						};
-
-						/**
-						 * Resumes audioContext if it is suspended. No-op if it not.
-						 */
-						const resumeAudioContext = () => {
-							const audioContext = audioRecorder.audioContext();
-							if (audioContext.state !== 'suspended') {
-								return Promise.resolve();
-							} else {
-								return audioContext.resume();
-							}
+							const context = audioRecorder.audioContext();
+							context.resume().then(() => {
+								recorder = audioRecorder.createRecorder(silenceDetectionConfig);
+								recorder.record(onSilence, visualizer);
+							});
 						};
 
 						/**

--- a/packages/aws-amplify-vue/src/components/interactions/aws-lex-audio.js
+++ b/packages/aws-amplify-vue/src/components/interactions/aws-lex-audio.js
@@ -106,8 +106,28 @@
 							if (!audioSupported) {
 								throw new Error(UNSUPPORTED);
 							}
-							recorder = audioRecorder.createRecorder(silenceDetectionConfig);
-							recorder.record(onSilence, visualizer);
+							resumeAudioContext()
+								.then(() => {
+									recorder = audioRecorder.createRecorder(
+										silenceDetectionConfig
+									);
+									recorder.record(onSilence, visualizer);
+								})
+								.catch(err => {
+									throw new Error(err);
+								});
+						};
+
+						/**
+						 * Resumes audioContext if it is suspended. No-op if it not.
+						 */
+						const resumeAudioContext = () => {
+							const audioContext = audioRecorder.audioContext();
+							if (audioContext.state !== 'suspended') {
+								return Promise.resolve();
+							} else {
+								return audioContext.resume();
+							}
 						};
 
 						/**

--- a/packages/interactions/__tests__/Interactions-unit-test.ts
+++ b/packages/interactions/__tests__/Interactions-unit-test.ts
@@ -7,6 +7,10 @@ import {
 	PostTextCommand,
 } from '@aws-sdk/client-lex-runtime-service';
 
+global.Response = () => {};
+global.Response.prototype.arrayBuffer = () => {
+	return Promise.resolve(new ArrayBuffer(0));
+};
 LexRuntimeServiceClient.prototype.send = jest.fn((command, callback) => {
 	if (command instanceof PostTextCommand) {
 		if (command.input.inputText === 'done') {
@@ -54,6 +58,7 @@ LexRuntimeServiceClient.prototype.send = jest.fn((command, callback) => {
 						m1: 'hi',
 						m2: 'done',
 					},
+					audioStream: new Uint8Array(),
 				};
 				return Promise.resolve(result);
 			} else {
@@ -351,6 +356,7 @@ describe('Interactions', () => {
 			expect(responseVoice).toEqual({
 				dialogState: 'ElicitSlot',
 				message: 'voice:echo:voice:hi',
+				audioStream: new Uint8Array(),
 			});
 
 			const responseText = await interactions.send(
@@ -360,6 +366,7 @@ describe('Interactions', () => {
 			expect(responseText).toEqual({
 				dialogState: 'ElicitSlot',
 				message: 'echo:hi',
+				audioStream: new Uint8Array(),
 			});
 		});
 
@@ -424,6 +431,7 @@ describe('Interactions', () => {
 			expect(responseVoice).toEqual({
 				dialogState: 'ElicitSlot',
 				message: 'voice:echo:voice:hi',
+				audioStream: new Uint8Array(),
 			});
 
 			const responseText = await interactions.send(
@@ -433,6 +441,7 @@ describe('Interactions', () => {
 			expect(responseText).toEqual({
 				dialogState: 'ElicitSlot',
 				message: 'echo:hi',
+				audioStream: new Uint8Array(),
 			});
 		});
 
@@ -501,6 +510,7 @@ describe('Interactions', () => {
 						m1: 'voice:hi',
 						m2: 'voice:done',
 					},
+					audioStream: new Uint8Array(),
 				});
 
 				const textResponse = await interactions.send(
@@ -514,6 +524,7 @@ describe('Interactions', () => {
 						m1: 'hi',
 						m2: 'done',
 					},
+					audioStream: new Uint8Array(),
 				});
 			});
 
@@ -582,6 +593,7 @@ describe('Interactions', () => {
 						m1: 'voice:hi',
 						m2: 'voice:done',
 					},
+					audioStream: new Uint8Array(),
 				});
 
 				const textResponse = await interactions.send(
@@ -595,6 +607,7 @@ describe('Interactions', () => {
 						m1: 'hi',
 						m2: 'done',
 					},
+					audioStream: new Uint8Array(),
 				});
 			});
 
@@ -836,6 +849,7 @@ describe('Interactions', () => {
 				expect(responseVoice).toEqual({
 					dialogState: 'ElicitSlot',
 					message: 'voice:echo:voice:hi',
+					audioStream: new Uint8Array(),
 				});
 
 				const responseText = await interactions.send(
@@ -845,6 +859,7 @@ describe('Interactions', () => {
 				expect(responseText).toEqual({
 					dialogState: 'ElicitSlot',
 					message: 'echo:hi',
+					audioStream: new Uint8Array(),
 				});
 			});
 		});

--- a/packages/interactions/__tests__/Interactions-unit-test.ts
+++ b/packages/interactions/__tests__/Interactions-unit-test.ts
@@ -495,14 +495,7 @@ describe('Interactions', () => {
 						m2: 'done',
 					},
 				});
-
-				const interactionsMessageVoice = {
-					content: 'voice:done',
-					options: {
-						messageType: 'voice',
-					},
-				};
-
+				
 				const interactionsMessageText = {
 					content: 'done',
 					options: {
@@ -612,14 +605,6 @@ describe('Interactions', () => {
 						m2: 'done',
 					},
 				});
-
-				const interactionsMessageVoice = {
-					content: 'voice:done',
-					options: {
-						messageType: 'voice',
-					},
-				};
-
 				const interactionsMessageText = {
 					content: 'done',
 					options: {

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -15,8 +15,7 @@ import {
 	InteractionsProviders,
 	InteractionsProvider,
 	InteractionsMessage,
-	InteractionsTextResponse,
-	InteractionsVoiceResponse,
+	InteractionsResponse,
 } from './types';
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 import { AWSLexProvider } from './Providers';
@@ -100,11 +99,11 @@ export class InteractionsClass {
 	public async send(
 		botname: string,
 		message: string
-	): Promise<InteractionsTextResponse>;
+	): Promise<InteractionsResponse>;
 	public async send(
 		botname: string,
 		message: InteractionsMessage
-	): Promise<InteractionsVoiceResponse>;
+	): Promise<InteractionsResponse>;
 	public async send(botname: string, message: object): Promise<object>;
 	public async send(
 		botname: string,

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -104,7 +104,7 @@ export class InteractionsClass {
 	public async send(
 		botname: string,
 		message: InteractionsMessage
-	): Promise<InteractionsVoiceResponse>; 
+	): Promise<InteractionsVoiceResponse>;
 	public async send(botname: string, message: object): Promise<object>;
 	public async send(
 		botname: string,

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -13,9 +13,10 @@
 import {
 	InteractionsOptions,
 	InteractionsProviders,
-	InteractionsResponse,
 	InteractionsProvider,
 	InteractionsMessage,
+	InteractionsTextResponse,
+	InteractionsVoiceResponse,
 } from './types';
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 import { AWSLexProvider } from './Providers';
@@ -96,12 +97,19 @@ export class InteractionsClass {
 		}
 	}
 
-	public async send(botname: string, message: string);
-	public async send(botname: string, message: Object);
 	public async send(
 		botname: string,
-		message: string | InteractionsMessage | Object
-	) {
+		message: string
+	): Promise<InteractionsTextResponse>;
+	public async send(
+		botname: string,
+		message: InteractionsMessage
+	): Promise<InteractionsVoiceResponse>; 
+	public async send(botname: string, message: object): Promise<object>;
+	public async send(
+		botname: string,
+		message: string | object
+	): Promise<object> {
 		if (!this._options.bots || !this._options.bots[botname]) {
 			throw new Error('Bot ' + botname + ' does not exist');
 		}

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -98,7 +98,10 @@ export class InteractionsClass {
 
 	public async send(botname: string, message: string);
 	public async send(botname: string, message: Object);
-	public async send(botname: string, message: string | InteractionsMessage | Object) {
+	public async send(
+		botname: string,
+		message: string | InteractionsMessage | Object
+	) {
 		if (!this._options.bots || !this._options.bots[botname]) {
 			throw new Error('Bot ' + botname + ' does not exist');
 		}

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -15,6 +15,8 @@ import {
 	InteractionsProviders,
 	InteractionsResponse,
 	InteractionsProvider,
+	InteractionsTextMessage,
+	InteractionsVoiceMessage,
 } from './types';
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 import { AWSLexProvider } from './Providers';
@@ -95,6 +97,9 @@ export class InteractionsClass {
 		}
 	}
 
+	public async send(botname: string, message: string);
+	public async send(botname: string, message: InteractionsTextMessage);
+	public async send(botname: string, message: InteractionsVoiceMessage);
 	public async send(botname: string, message: string | Object) {
 		if (!this._options.bots || !this._options.bots[botname]) {
 			throw new Error('Bot ' + botname + ' does not exist');

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -15,8 +15,7 @@ import {
 	InteractionsProviders,
 	InteractionsResponse,
 	InteractionsProvider,
-	InteractionsTextMessage,
-	InteractionsVoiceMessage,
+	InteractionsMessage,
 } from './types';
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 import { AWSLexProvider } from './Providers';
@@ -98,9 +97,8 @@ export class InteractionsClass {
 	}
 
 	public async send(botname: string, message: string);
-	public async send(botname: string, message: InteractionsTextMessage);
-	public async send(botname: string, message: InteractionsVoiceMessage);
-	public async send(botname: string, message: string | Object) {
+	public async send(botname: string, message: Object);
+	public async send(botname: string, message: string | InteractionsMessage | Object) {
 		if (!this._options.bots || !this._options.bots[botname]) {
 			throw new Error('Bot ' + botname + ' does not exist');
 		}

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
@@ -1,8 +1,4 @@
-import { AcceptType } from '../../types';
-export const convert = (
-	stream: Blob,
-	accept: AcceptType
-): Promise<Uint8Array> => {
+export const convert = (stream: Blob): Promise<Uint8Array> => {
 	return new Promise(async (res, rej) => {
 		const blobURL = URL.createObjectURL(stream);
 		const request = new XMLHttpRequest();

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
@@ -1,12 +1,9 @@
 import { AcceptType } from '../../types';
-export const convertOnBrowser = (
+export const convert = (
 	stream: Blob,
 	accept: AcceptType
 ): Promise<ArrayBuffer | Blob | Uint8Array> => {
     return new Promise(async (res, rej) => {
-        if (!(stream instanceof Blob)) {
-            return rej(`Unexpected response type 'ReadableStream' in React Native`);
-        }
         const blobURL = URL.createObjectURL(stream);
         const request = new XMLHttpRequest();
         request.responseType = 'arraybuffer';

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
@@ -2,20 +2,16 @@ import { AcceptType } from '../../types';
 export const convert = (
 	stream: Blob,
 	accept: AcceptType
-): Promise<ArrayBuffer | Blob | Uint8Array> => {
-    return new Promise(async (res, rej) => {
-        const blobURL = URL.createObjectURL(stream);
-        const request = new XMLHttpRequest();
-        request.responseType = 'arraybuffer';
-        request.onload = _event => {
-            if (accept === 'ArrayBuffer') {
-                return res(request.response);
-            } else {
-                return res(new Uint8Array(request.response));
-            }
-        };
-        request.onerror = rej;
-        request.open('GET', blobURL, true);
-        request.send();
-    });
+): Promise<Uint8Array> => {
+	return new Promise(async (res, rej) => {
+		const blobURL = URL.createObjectURL(stream);
+		const request = new XMLHttpRequest();
+		request.responseType = 'arraybuffer';
+		request.onload = _event => {
+			return res(new Uint8Array(request.response));
+		};
+		request.onerror = rej;
+		request.open('GET', blobURL, true);
+		request.send();
+	});
 };

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.native.ts
@@ -1,0 +1,24 @@
+import { AcceptType } from '../../types';
+export const convertOnBrowser = (
+	stream: Blob,
+	accept: AcceptType
+): Promise<ArrayBuffer | Blob | Uint8Array> => {
+    return new Promise(async (res, rej) => {
+        if (!(stream instanceof Blob)) {
+            return rej(`Unexpected response type 'ReadableStream' in React Native`);
+        }
+        const blobURL = URL.createObjectURL(stream);
+        const request = new XMLHttpRequest();
+        request.responseType = 'arraybuffer';
+        request.onload = _event => {
+            if (accept === 'ArrayBuffer') {
+                return res(request.response);
+            } else {
+                return res(new Uint8Array(request.response));
+            }
+        };
+        request.onerror = rej;
+        request.open('GET', blobURL, true);
+        request.send();
+    });
+};

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.ts
@@ -4,12 +4,9 @@ export const convert = (
 	stream: Readable | ReadableStream | Blob,
 	accept: AcceptType
 ): Promise<ArrayBuffer | Blob | Uint8Array> => {
-	console.log('hello');
-	// if (stream instanceof Readable) {
-	// 	throw new Error('Node.js is not supported currently.');
-	// } else {
-	if (stream instanceof ArrayBuffer || stream instanceof Blob) {
-		// stream instanceof ReadableStream | Blob
+	if (stream instanceof Readable) {
+		throw new Error('Node.js is not supported currently.');
+	} else { // if stream instanceof ReadableStream | Blob
 		const response = new Response(stream);
 		if (accept === 'ArrayBuffer') {
 			return response.arrayBuffer();

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.ts
@@ -1,19 +1,30 @@
 import { Readable } from 'stream';
 import { AcceptType } from '../../types';
-export const convert = (
+export const convert = async (
 	stream: Readable | ReadableStream | Blob,
 	accept: AcceptType
 ): Promise<ArrayBuffer | Blob | Uint8Array> => {
-	if (stream instanceof Readable) {
-		throw new Error('Node.js is not supported currently.');
-	} else { // if stream instanceof ReadableStream | Blob
-		const response = new Response(stream);
-		if (accept === 'ArrayBuffer') {
-			return response.arrayBuffer();
-		} else if (accept === 'Blob') {
-			return response.blob();
-		} else {
-			return response.arrayBuffer().then(buffer => new Uint8Array(buffer));
-		}
+	let audio = stream instanceof Readable ? await readReadable(stream) : stream;
+	const response = new Response(audio);
+	if (accept === 'ArrayBuffer') {
+		return response.arrayBuffer();
+	} else if (accept === 'Blob') {
+		return response.blob();
+	} else {
+		return response.arrayBuffer().then(buffer => new Uint8Array(buffer));
 	}
+};
+
+const readReadable = (stream: Readable): Promise<Blob> => {
+	if (!stream.isPaused()) stream.pause();
+	let chunks: Array<string | Buffer> = [];
+	return new Promise((res, rej) => {
+		stream.on('data', chunk => {
+			chunks.push(chunk);
+		});
+		stream.on('end', () => {
+			return res(new Blob(chunks));
+		});
+		stream.on('error', rej);
+	});
 };

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.ts
@@ -1,5 +1,4 @@
 import { Readable } from 'stream';
-import { AcceptType } from '../../types';
 export const convert = async (
 	stream: Readable | ReadableStream | Blob
 ): Promise<Uint8Array> => {

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.ts
@@ -1,0 +1,22 @@
+import { Readable } from 'stream';
+import { AcceptType } from '../../types';
+export const convert = (
+	stream: Readable | ReadableStream | Blob,
+	accept: AcceptType
+): Promise<ArrayBuffer | Blob | Uint8Array> => {
+	console.log('hello');
+	// if (stream instanceof Readable) {
+	// 	throw new Error('Node.js is not supported currently.');
+	// } else {
+	if (stream instanceof ArrayBuffer || stream instanceof Blob) {
+		// stream instanceof ReadableStream | Blob
+		const response = new Response(stream);
+		if (accept === 'ArrayBuffer') {
+			return response.arrayBuffer();
+		} else if (accept === 'Blob') {
+			return response.blob();
+		} else {
+			return response.arrayBuffer().then(buffer => new Uint8Array(buffer));
+		}
+	}
+};

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.ts
@@ -1,18 +1,12 @@
 import { Readable } from 'stream';
 import { AcceptType } from '../../types';
 export const convert = async (
-	stream: Readable | ReadableStream | Blob,
-	accept: AcceptType
-): Promise<ArrayBuffer | Blob | Uint8Array> => {
+	stream: Readable | ReadableStream | Blob
+): Promise<Uint8Array> => {
 	let audio = stream instanceof Readable ? await readReadable(stream) : stream;
-	const response = new Response(audio);
-	if (accept === 'ArrayBuffer') {
-		return response.arrayBuffer();
-	} else if (accept === 'Blob') {
-		return response.blob();
-	} else {
-		return response.arrayBuffer().then(buffer => new Uint8Array(buffer));
-	}
+	return new Response(audio)
+		.arrayBuffer()
+		.then(buffer => new Uint8Array(buffer));
 };
 
 const readReadable = (stream: Readable): Promise<Blob> => {

--- a/packages/interactions/src/Providers/AWSLexHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexHelper/convert.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream';
 export const convert = async (
 	stream: Readable | ReadableStream | Blob
 ): Promise<Uint8Array> => {
-	let audio = stream instanceof Readable ? await readReadable(stream) : stream;
+	const audio = stream instanceof Readable ? await readReadable(stream) : stream;
 	return new Response(audio)
 		.arrayBuffer()
 		.then(buffer => new Uint8Array(buffer));
@@ -10,7 +10,7 @@ export const convert = async (
 
 const readReadable = (stream: Readable): Promise<Blob> => {
 	if (!stream.isPaused()) stream.pause();
-	let chunks: Array<string | Buffer> = [];
+	const chunks: Array<string | Buffer> = [];
 	return new Promise((res, rej) => {
 		stream.on('data', chunk => {
 			chunks.push(chunk);

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -128,12 +128,16 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 				return Promise.reject(err);
 			}
 		} else {
-			if (typeof message.content !== 'string') {
+			const {
+				content,
+				options: { messageType },
+			} = message;
+			if (messageType === 'voice') {
 				params = {
 					botAlias: this._config[botname].alias,
 					botName: botname,
 					contentType: 'audio/x-l16; sample-rate=16000',
-					inputStream: message.content,
+					inputStream: content,
 					userId: credentials.identityId,
 					accept: 'audio/mpeg',
 				};
@@ -142,7 +146,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 					botAlias: this._config[botname].alias,
 					botName: botname,
 					contentType: 'text/plain; charset=utf-8',
-					inputStream: message.content,
+					inputStream: content,
 					userId: credentials.identityId,
 					accept: 'audio/mpeg',
 				};
@@ -150,7 +154,9 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 			logger.debug('postContent to lex', message);
 			try {
 				const postContentCommand = new PostContentCommand(params);
-				let data = await this.lexRuntimeServiceClient.send(postContentCommand);
+				const data = await this.lexRuntimeServiceClient.send(
+					postContentCommand
+				);
 				const audioArray = await convert(data.audioStream);
 				this.reportBotStatus(data, botname);
 				return { ...data, ...{ audioStream: audioArray } };

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -124,16 +124,12 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 				return Promise.reject(err);
 			}
 		} else {
-			const {
-				content,
-				options: { messageType, accept = 'Uint8Array' },
-			} = message;
-			if (messageType === 'voice') {
+			if (typeof message.content !== 'string') {
 				params = {
 					botAlias: this._config[botname].alias,
 					botName: botname,
 					contentType: 'audio/x-l16; sample-rate=16000',
-					inputStream: content,
+					inputStream: message.content,
 					userId: credentials.identityId,
 					accept: 'audio/mpeg',
 				};
@@ -142,7 +138,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 					botAlias: this._config[botname].alias,
 					botName: botname,
 					contentType: 'text/plain; charset=utf-8',
-					inputStream: content,
+					inputStream: message.content,
 					userId: credentials.identityId,
 					accept: 'audio/mpeg',
 				};
@@ -151,7 +147,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 			try {
 				const postContentCommand = new PostContentCommand(params);
 				let data = await this.lexRuntimeServiceClient.send(postContentCommand);
-				const audioArray = await convert(data.audioStream, accept);
+				const audioArray = await convert(data.audioStream, 'Uint8Array');
 				this.reportBotStatus(data, botname);
 				return { ...data, ...{ audioStream: audioArray } }; // TODO: type the response type
 			} catch (err) {

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -12,7 +12,11 @@
  */
 
 import { AbstractInteractionsProvider } from './InteractionsProvider';
-import { InteractionsOptions, InteractionsMessage, InteractionsResponse } from '../types';
+import {
+	InteractionsOptions,
+	InteractionsResponse,
+	InteractionsMessage,
+} from '../types';
 import {
 	LexRuntimeServiceClient,
 	PostTextCommand,
@@ -149,7 +153,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 				let data = await this.lexRuntimeServiceClient.send(postContentCommand);
 				const audioArray = await convert(data.audioStream);
 				this.reportBotStatus(data, botname);
-				return { ...data, ...{ audioStream: audioArray } }; // TODO: type the response type
+				return { ...data, ...{ audioStream: audioArray } }; 
 			} catch (err) {
 				return Promise.reject(err);
 			}

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -152,7 +152,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 				const accept: AcceptType = message.options.accept || 'Uint8Array';
 				const audioArray = await convert(data.audioStream, accept);
 				this.reportBotStatus(data, botname);
-				return { ...data, ...{ audioStream: audioArray } }; // TODO: type the function type
+				return { ...data, ...{ audioStream: audioArray } }; // TODO: type the response type
 			} catch (err) {
 				return Promise.reject(err);
 			}

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -12,7 +12,7 @@
  */
 
 import { AbstractInteractionsProvider } from './InteractionsProvider';
-import { InteractionsOptions, InteractionsMessage } from '../types';
+import { InteractionsOptions, InteractionsMessage, InteractionsResponse } from '../types';
 import {
 	LexRuntimeServiceClient,
 	PostTextCommand,
@@ -89,7 +89,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 	async sendMessage(
 		botname: string,
 		message: string | InteractionsMessage
-	): Promise<object> {
+	): Promise<InteractionsResponse> {
 		if (!this._config[botname]) {
 			return Promise.reject('Bot ' + botname + ' does not exist');
 		}

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -153,7 +153,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 				let data = await this.lexRuntimeServiceClient.send(postContentCommand);
 				const audioArray = await convert(data.audioStream);
 				this.reportBotStatus(data, botname);
-				return { ...data, ...{ audioStream: audioArray } }; 
+				return { ...data, ...{ audioStream: audioArray } };
 			} catch (err) {
 				return Promise.reject(err);
 			}

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -147,7 +147,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 			try {
 				const postContentCommand = new PostContentCommand(params);
 				let data = await this.lexRuntimeServiceClient.send(postContentCommand);
-				const audioArray = await convert(data.audioStream, 'Uint8Array');
+				const audioArray = await convert(data.audioStream);
 				this.reportBotStatus(data, botname);
 				return { ...data, ...{ audioStream: audioArray } }; // TODO: type the response type
 			} catch (err) {

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -23,6 +23,7 @@ import {
 	Credentials,
 	getAmplifyUserAgent,
 } from '@aws-amplify/core';
+import { Readable } from 'stream';
 
 const logger = new Logger('AWSLexProvider');
 
@@ -151,10 +152,24 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 					postContentCommand
 				);
 				this.reportBotStatus(data, botname);
-				return data;
+
+				const audioArray = await this.streamToArray(data.audioStream);
+				return { ...data, ...{ audioStream: audioArray } };
 			} catch (err) {
 				return Promise.reject(err);
 			}
+		}
+	}
+
+	private streamToArray(
+		stream: Readable | ReadableStream | Blob
+	): Promise<Uint8Array> {
+		const audioArray = new Uint8Array();
+		if (stream instanceof Readable) {
+			throw new ErrorEvent('Node.js is not supported currently.');
+		} else {
+			// stream: ReadableStream | Blob
+			return new Response(stream).arrayBuffer().then(buffer => new Uint8Array(buffer));
 		}
 	}
 

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -14,6 +14,20 @@ export interface InteractionsOptions {
 	[key: string]: any;
 }
 
-export type InteractionsMessage = {
-	content: string | Object;
+export type InteractionsTextMessage = {
+	content: string;
+	options: {
+		messageType: 'text';
+	};
 };
+
+export type InteractionsVoiceMessage = {
+	content: string | object;
+	options: {
+		messageType: 'voice';
+	};
+};
+
+export type InteractionsMessage =
+	| InteractionsTextMessage
+	| InteractionsVoiceMessage;

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -16,10 +16,20 @@ export interface InteractionsOptions {
 
 export type AcceptType = 'ArrayBuffer' | 'Blob' | 'Uint8Array';
 
-export interface InteractionsMessage {
-	content: string | Object;
+export interface InteractionsTextMessage {
+	content: string;
 	options: {
-		messageType: 'voice' | 'text'
+		messageType: 'text'
+		accept?: AcceptType;
+	};
+} 
+
+export interface InteractionsVoiceMessage {
+	content: Object;
+	options: {
+		messageType: 'voice'
 		accept?: AcceptType;
 	};
 }
+
+export type InteractionsMessage = InteractionsVoiceMessage | InteractionsTextMessage;

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -14,8 +14,6 @@ export interface InteractionsOptions {
 	[key: string]: any;
 }
 
-export type AcceptType = 'ArrayBuffer' | 'Blob' | 'Uint8Array';
-
 export type InteractionsMessage = {
 	content: string | Object;
 };

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -16,20 +16,6 @@ export interface InteractionsOptions {
 
 export type AcceptType = 'ArrayBuffer' | 'Blob' | 'Uint8Array';
 
-export interface InteractionsTextMessage {
-	content: string;
-	options: {
-		messageType: 'text'
-		accept?: AcceptType;
-	};
-} 
-
-export interface InteractionsVoiceMessage {
-	content: Object;
-	options: {
-		messageType: 'voice'
-		accept?: AcceptType;
-	};
-}
-
-export type InteractionsMessage = InteractionsVoiceMessage | InteractionsTextMessage;
+export type InteractionsMessage = {
+	content: string | Object
+};

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -14,9 +14,12 @@ export interface InteractionsOptions {
 	[key: string]: any;
 }
 
+export type AcceptType = 'ArrayBuffer' | 'Blob' | 'Uint8Array';
+
 export interface InteractionsMessage {
 	content: string | Object;
 	options: {
 		[key: string]: string;
+		accept?: AcceptType;
 	};
 }

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -17,5 +17,5 @@ export interface InteractionsOptions {
 export type AcceptType = 'ArrayBuffer' | 'Blob' | 'Uint8Array';
 
 export type InteractionsMessage = {
-	content: string | Object
+	content: string | Object;
 };

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -19,7 +19,7 @@ export type AcceptType = 'ArrayBuffer' | 'Blob' | 'Uint8Array';
 export interface InteractionsMessage {
 	content: string | Object;
 	options: {
-		[key: string]: string;
+		messageType: 'voice' | 'text'
 		accept?: AcceptType;
 	};
 }

--- a/packages/interactions/src/types/Response.ts
+++ b/packages/interactions/src/types/Response.ts
@@ -10,18 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import {
-	PostTextResponse,
-	PostContentResponse,
-} from '@aws-sdk/client-lex-runtime-service';
 
-export type InteractionsTextResponse = PostTextResponse;
-export type InteractionsVoiceResponse = Omit<
-	PostContentResponse,
-	'audioStream'
-> & {
-	audioStream: Uint8Array;
+export type InteractionsResponse = {
+	[key: string]: any;
 };
-export type InteractionsResponse =
-	| InteractionsTextResponse
-	| InteractionsVoiceResponse;

--- a/packages/interactions/src/types/Response.ts
+++ b/packages/interactions/src/types/Response.ts
@@ -20,8 +20,8 @@ export type InteractionsVoiceResponse = Omit<
 	PostContentResponse,
 	'audioStream'
 > & {
-	audioStream: Uint8Array | ArrayBuffer | Blob;
+	audioStream: Uint8Array;
 };
 export type InteractionsResponse =
 	| InteractionsTextResponse
-	| InteractionsVoiceResponse;
+	| InteractionsVoiceResponse

--- a/packages/interactions/src/types/Response.ts
+++ b/packages/interactions/src/types/Response.ts
@@ -24,4 +24,4 @@ export type InteractionsVoiceResponse = Omit<
 };
 export type InteractionsResponse =
 	| InteractionsTextResponse
-	| InteractionsVoiceResponse
+	| InteractionsVoiceResponse;

--- a/packages/interactions/src/types/Response.ts
+++ b/packages/interactions/src/types/Response.ts
@@ -10,6 +10,18 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-export interface InteractionsResponse {
-	[key: string]: any;
-}
+import {
+	PostTextResponse,
+	PostContentResponse,
+} from '@aws-sdk/client-lex-runtime-service';
+
+export type InteractionsTextResponse = PostTextResponse;
+export type InteractionsVoiceResponse = Omit<
+	PostContentResponse,
+	'audioStream'
+> & {
+	audioStream: Uint8Array | ArrayBuffer | Blob;
+};
+export type InteractionsResponse =
+	| InteractionsTextResponse
+	| InteractionsVoiceResponse;


### PR DESCRIPTION
Squashing commit so that the main PR to upstream is cleaner.

----

This PR fixes current bugs with the Interactions category and strongly types the `Interactions.send()` request.

#### Bug fixes:
- Convert `aws-sdk-js-v3` response from `Lex.PostContent` to `Uint8Array` so that it aligns with v2 behavior.
    - This works on browsers, react native, and Node.js.
- Fix ReferenceError (uninitialized variable) in react native chatbot ui. 
- Resume `AudioContext` when user presses the voice chat button.

#### Unit Test:
- Fix a bug where `jest.runAllTimers()` were called prematurely. This prevented `onComplete` callbacks from running and jest passed the tests vacuously.
- Fix a bug where jest was falsely expecting `onComplete` callback from text messages even when it sends voice messages. 
- Add `audioStream` to mock response and test whether it converts stream to `Uint8Array` correctly. 

#### Category Refactor:
- Strongly type `Interactions.send` API request type.
- Overload `Interactions.send` so that developers can see the API in detail from their editor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
